### PR TITLE
updates for 4.6.8

### DIFF
--- a/onprem-environment
+++ b/onprem-environment
@@ -17,7 +17,8 @@ DEPLOY_TARGET=onprem
 DUMMY_IGNITION=false
 
 #OPENSHIFT_INSTALL_RELEASE_IMAGE=quay.io/ocpmetal/ocp-release:latest
-OPENSHIFT_INSTALL_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.6.1-x86_64
+OPENSHIFT_INSTALL_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.6.8-x86_64
+OPENSHIFT_VERSIONS={"4.6":{"release_image":"quay.io/openshift-release-dev/ocp-release:4.6.8-x86_64"},"4.7":{"release_image":"quay.io/openshift-release-dev/ocp-release@sha256:2419f9cd3ea9bd114764855653012e305ade2527210d332bfdd6dbdae538bd66"}}
 
 # Host IPs service will be listening 
 #SERVICE_IPS=<Comma separated list of host IPs where the service should listed>

--- a/start-assisted-service.sh
+++ b/start-assisted-service.sh
@@ -16,7 +16,7 @@ else
     OAS_IMAGE=quay.io/eranco74/bm-inventory:onprem_single_node
 fi
 
-RHCOS_VERSION="4.6.1"
+RHCOS_VERSION="4.6.8"
 BASE_OS_IMAGE=https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/${RHCOS_VERSION}/rhcos-${RHCOS_VERSION}-x86_64-live.x86_64.iso
 
 OAS_UI_IMAGE=quay.io/ocpmetal/ocp-metal-ui:latest


### PR DESCRIPTION
This should be a working update for `4.6.8` OCP changes with AI `1.5.2-1`.

I'll follow up with this PR and use `stable` over `latest` tags after I double-check them. Please hold merging this PR, until I have a moment to validate these improvements.