### PR TITLE
add updates for mirroring airgapped images 21-jan

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 ```
 
 ## Dependencies
+- Requires [podman](https://podman.io/)
 
 - Create and update required configuration files:
   - [`/opt/assisted-service/onprem-environment`](./onprem-environment)
@@ -15,17 +16,17 @@
 ## Running Assisted Service
 
 - To start the assisted service
-  
+
   ```bash
   ./start-assisted-service.sh
   ```
 
 - To stop the assisted service
-  
+
   ```bash
   ./stop-assisted-service.sh
   ```
-  
+
 ## Using Assisted Service
 
 - The UI will available at: `http://<host-ip-address>:8888`

--- a/assisted-restrictednetwork-images.sh
+++ b/assisted-restrictednetwork-images.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+echo  ########################################################################
+echo  # Mirror Extra Images for Assisted Installer, Restricted Network Install
+echo  ########################################################################
+
+# Input environment variables suiting your installation below
+
+LOCAL_REGISTRY="yourregistry.fqdn:5000"
+PULL_SECRET_JSON=../../pull-secret-full.json
+
+IMAGE="coreos-installer"
+oc -a $PULL_SECRET_JSON image mirror quay.io/coreos/$IMAGE:v0.7.0 $LOCAL_REGISTRY/coreos/$IMAGE:v0.7.0 --insecure=true
+
+for IMAGE in postgresql-12-centos7 ocp-metal-ui agent assisted-installer-agent assisted-iso-create assisted-installer assisted-installer-controller assisted-service
+do
+   oc -a $PULL_SECRET_JSON image mirror quay.io/ocpmetal/$IMAGE:latest $LOCAL_REGISTRY/ocpmetal/$IMAGE:latest --insecure=true
+   echo "Pushed to $LOCAL_REGISTRY/ocpmetal/$IMAGE:latest"
+done

--- a/onprem-environment
+++ b/onprem-environment
@@ -7,7 +7,7 @@ SERVICE_BASE_URL=http://10.198.6.70:8090
 ###############################
 # NO NEED TO UPDATE AFTER THIS
 ###############################
-# Host IPs service will be listening 
+# Host IPs service will be listening
 #SERVICE_IPS=<Comma separated list of host IPs where the service should listed>
 
 # Required when using self-signed certifications or no certificates
@@ -24,9 +24,9 @@ DB_USER=admin
 DB_PASS=admin
 DB_NAME=installer
 
-#OPENSHIFT_INSTALL_RELEASE_IMAGE=quay.io/ocpmetal/ocp-release:latest
-OPENSHIFT_INSTALL_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.6.9-x86_64
-OPENSHIFT_VERSIONS={"4.6":{"release_image":"quay.io/openshift-release-dev/ocp-release:4.6.9-x86_64"},"4.7":{"release_image":"quay.io/openshift-release-dev/ocp-release@sha256:2419f9cd3ea9bd114764855653012e305ade2527210d332bfdd6dbdae538bd66"}}
+#OPENSHIFT_INSTALL_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.6.8-x86_64
+OPENSHIFT_INSTALL_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release@sha256:6ddbf56b7f9776c0498f23a54b65a06b3b846c1012200c5609c4bb716b6bdcdf
+OPENSHIFT_VERSIONS={"4.6":{"release_image":"quay.io/openshift-release-dev/ocp-release@sha256:6ddbf56b7f9776c0498f23a54b65a06b3b846c1012200c5609c4bb716b6bdcdf"},"4.7":{"release_image":"quay.io/openshift-release-dev/ocp-release@sha256:2419f9cd3ea9bd114764855653012e305ade2527210d332bfdd6dbdae538bd66"}}
 
 # Uncomment to avoid pull-secret requirement for quay.io on Air-gapped deployments
 #PUBLIC_CONTAINER_REGISTRIES=quay.io,registry.access.redhat.com,registry.redhat.io

--- a/onprem-environment
+++ b/onprem-environment
@@ -24,8 +24,9 @@ DB_USER=admin
 DB_PASS=admin
 DB_NAME=installer
 
-#OPENSHIFT_INSTALL_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.6.8-x86_64
-OPENSHIFT_INSTALL_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release@sha256:6ddbf56b7f9776c0498f23a54b65a06b3b846c1012200c5609c4bb716b6bdcdf
+OPENSHIFT_INSTALL_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release:4.6.8-x86_64
+# uncomment below for restricted network install pulling by digest instead of tag
+#OPENSHIFT_INSTALL_RELEASE_IMAGE=quay.io/openshift-release-dev/ocp-release@sha256:6ddbf56b7f9776c0498f23a54b65a06b3b846c1012200c5609c4bb716b6bdcdf
 OPENSHIFT_VERSIONS={"4.6":{"release_image":"quay.io/openshift-release-dev/ocp-release@sha256:6ddbf56b7f9776c0498f23a54b65a06b3b846c1012200c5609c4bb716b6bdcdf"},"4.7":{"release_image":"quay.io/openshift-release-dev/ocp-release@sha256:2419f9cd3ea9bd114764855653012e305ade2527210d332bfdd6dbdae538bd66"}}
 
 # Uncomment to avoid pull-secret requirement for quay.io on Air-gapped deployments

--- a/start-assisted-service.sh
+++ b/start-assisted-service.sh
@@ -1,23 +1,24 @@
 #!/bin/bash
 
 echo  ####################################
-echo  # Deploy Assited Installer 
+echo  # Deploy Assited Installer
 echo  ####################################
 
 # Note:
 # - TCP/5432 Postgres: There is no need to export the PostgreSQL port (5432) outside the Pod
-# - TCP/8000: 
+# - TCP/8000:
 # - TCP/8090: API
 # - TCP/8888: UI
 
 if [[ "$1" != "single" ]]; then
-    OAS_IMAGE=quay.io/ocpmetal/assisted-service:stable
+    #OAS_IMAGE=quay.io/ocpmetal/assisted-service:stable
+    OAS_IMAGE=quay.io/ocpmetal/assisted-service:stable-candidate.11.01.2021-15.13
 else
     OAS_IMAGE=quay.io/eranco74/bm-inventory:onprem_single_node
 fi
 
 ########################################################################
-RHCOS_VERSION="latest"
+RHCOS_VERSION="4.6.8"
 BASE_OS_IMAGE=https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/${RHCOS_VERSION}/rhcos-live.x86_64.iso
 
 OAS_UI_IMAGE=quay.io/ocpmetal/ocp-metal-ui:latest


### PR DESCRIPTION
added restricted network install image pull script for restricted/disconnected network installs so AI can pull images it needs.
also release image modified to digest as hosted images can't pull by tags
OAS image also changed to known working copy at the time of this PR authoring