### PR TITLE
Updating for 4.8.x pre-release and hardware validation

### DIFF
--- a/assisted-restrictednetwork-images.sh
+++ b/assisted-restrictednetwork-images.sh
@@ -10,7 +10,7 @@ LOCAL_REGISTRY="yourregistry.fqdn:5000"
 PULL_SECRET_JSON=../../pull-secret-full.json
 
 IMAGE="coreos-installer"
-oc -a $PULL_SECRET_JSON image mirror quay.io/coreos/$IMAGE:v0.7.0 $LOCAL_REGISTRY/coreos/$IMAGE:v0.7.0 --insecure=true
+oc -a $PULL_SECRET_JSON image mirror quay.io/coreos/$IMAGE:v0.9.1 $LOCAL_REGISTRY/coreos/$IMAGE:v0.9.1 --insecure=true
 
 for IMAGE in postgresql-12-centos7 ocp-metal-ui agent assisted-installer-agent assisted-iso-create assisted-installer assisted-installer-controller assisted-service
 do

--- a/onprem-environment
+++ b/onprem-environment
@@ -28,7 +28,7 @@ DB_USER=admin
 DB_PASS=admin
 DB_NAME=installer
 
-OPENSHIFT_VERSIONS={"4.6":{"display_name":"4.6.16","release_image":"quay.io/openshift-release-dev/ocp-release:4.6.16-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso","rhcos_version":"46.82.202012051820-0","support_level":"production"},"4.7":{"display_name":"4.7.2","release_image":"quay.io/openshift-release-dev/ocp-release:4.7.2-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.0/rhcos-4.7.0-x86_64-live.x86_64.iso","rhcos_version":"47.83.202102090044-0","support_level":"production"}}
+OPENSHIFT_VERSIONS={"4.6":{"display_name":"4.6.16","release_version":"4.6.16","release_image":"quay.io/openshift-release-dev/ocp-release:4.6.16-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso","rhcos_rootfs":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-live-rootfs.x86_64.img","rhcos_version":"46.82.202012051820-0","support_level":"production"},"4.7":{"display_name":"4.7.9","release_version":"4.7.9","release_image":"quay.io/openshift-release-dev/ocp-release:4.7.9-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-4.7.7-x86_64-live.x86_64.iso","rhcos_rootfs":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.7/rhcos-live-rootfs.x86_64.img","rhcos_version":"47.83.202103251640-0","support_level":"production","default":true},"4.8":{"display_name":"4.8.0-fc.3","release_version":"4.8.0-fc.3","release_image":"quay.io/openshift-release-dev/ocp-release:4.8.0-fc.3-x86_64","rhcos_image":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.8.0-fc.3/rhcos-4.8.0-fc.3-x86_64-live.x86_64.iso","rhcos_rootfs":"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.8.0-fc.3/rhcos-live-rootfs.x86_64.img","rhcos_version":"48.84.202105062123-0","support_level":"beta"}}
 
 # (OLD INFO NEED TO UPDATE)
 # Uncomment the below lines for restricted network install, requires pulling by digest
@@ -39,14 +39,8 @@ OPENSHIFT_VERSIONS={"4.6":{"display_name":"4.6.16","release_image":"quay.io/open
 # Uncomment to avoid pull-secret requirement for quay.io on restricted network installs
 #PUBLIC_CONTAINER_REGISTRIES=quay.io,registry.access.redhat.com,registry.redhat.io
 
-# https://github.com/openshift/assisted-test-infra/blob/master/discovery-infra/update_assisted_service_cm.py#L20
-HW_VALIDATOR_MIN_CPU_CORES=4
-HW_VALIDATOR_MIN_CPU_CORES_WORKER=4
-HW_VALIDATOR_MIN_CPU_CORES_MASTER=4
-HW_VALIDATOR_MIN_RAM_GIB=4
-HW_VALIDATOR_MIN_RAM_GIB_WORKER=4
-HW_VALIDATOR_MIN_RAM_GIB_MASTER=6
-HW_VALIDATOR_MIN_DISK_SIZE_GIB=20
+# Format has changed for HW validation (Link: https://github.com/openshift/assisted-service/blob/master/onprem-environment#L19)
+HW_VALIDATOR_REQUIREMENTS=[{"version":"default","master":{"cpu_cores":4,"ram_mib":6144,"disk_size_gb":20,"installation_disk_speed_threshold_ms":10},"worker":{"cpu_cores":4,"ram_mib":4096,"disk_size_gb":20,"installation_disk_speed_threshold_ms":10}}]
 
 #PULL_SECRET_TOKEN=
 #PULL_SECRET=
@@ -59,7 +53,8 @@ HW_VALIDATOR_MIN_DISK_SIZE_GIB=20
 #INVENTORY_IMAGE=
 #OCM_BASE_URL=
 
-#ENABLE_SINGLE_NODE_DNSMASQ=true
+# Enabled for SNO Deployments (Link: https://github.com/openshift/assisted-service/blob/master/onprem-environment#L14)
+ENABLE_SINGLE_NODE_DNSMASQ=true
 
 #####################################################################################
 ##  Experimental: Single Node deployment

--- a/start-assisted-service.sh
+++ b/start-assisted-service.sh
@@ -12,12 +12,17 @@ echo  ####################################
 
 ########################################################################
 RHCOS_VERSION="latest"
-BASE_OS_IMAGE=https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/${RHCOS_VERSION}/rhcos-live.x86_64.iso
+
+# BASE_OS_IMAGE matches current release, which is 4.7.x
+BASE_OS_IMAGE=https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/${RHCOS_VERSION}/rhcos-live.x86_64.iso
+
+# For 4.8.0-fc.3 SNO deployments, replace BASE_OS_IMAGE with the following URL:
+# BASE_OS_IMAGE=https://mirror.openshift.com/pub/openshift-v4/amd64/dependencies/rhcos/pre-release/latest-4.8/rhcos-4.8.0-fc.4-x86_64-live.x86_64.iso
 
 OAS_UI_IMAGE=quay.io/ocpmetal/ocp-metal-ui:latest
 OAS_DB_IMAGE=quay.io/ocpmetal/postgresql-12-centos7
 OAS_IMAGE=quay.io/ocpmetal/assisted-service:stable
-COREOS_INSTALLER=quay.io/coreos/coreos-installer:v0.7.0
+COREOS_INSTALLER=quay.io/coreos/coreos-installer:v0.9.1
 
 OAS_HOSTDIR=/opt/assisted-service
 OAS_ENV_FILE=${OAS_HOSTDIR}/onprem-environment

--- a/start-assisted-service.sh
+++ b/start-assisted-service.sh
@@ -21,7 +21,7 @@ BASE_OS_IMAGE=https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4
 
 OAS_UI_IMAGE=quay.io/ocpmetal/ocp-metal-ui:latest
 OAS_DB_IMAGE=quay.io/ocpmetal/postgresql-12-centos7
-OAS_IMAGE=quay.io/ocpmetal/assisted-service:stable
+OAS_IMAGE=quay.io/ocpmetal/assisted-service:latest
 COREOS_INSTALLER=quay.io/coreos/coreos-installer:v0.9.1
 
 OAS_HOSTDIR=/opt/assisted-service


### PR DESCRIPTION
This update allows for 4.8.x SNO deployments with CNV (and previous 4.6.x and 4.7.x), and also modifies the required HW environment settings, which is now provided in `json` format.

Signed-off-by: Brandon B. Jozsa <bjozsa@jinkit.com>